### PR TITLE
Added template settings to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,21 @@ The plugin will compile the template after requirejs `r.js` optimizer.
 And also when developing, it will compile the template the first time is loaded so that the next
 time is required it will just render the template saving a function call to underscore's internal render method.
 
+## Configuration
+
+You can pass underscoreTemplateSettings to RequireJS config
+
+```javascript
+requirejs.config({
+  config: {
+    underscoreTemplateSettings: {
+      interpolate: /\{\{\s*([^#\{]+?)\s*\}\}/g,  // {{ title }}
+      evaluate:    /\{\{#([\s\S]+?)\}\}/g,       // {{# console.log("stuff") }}
+      escape:      /\{\{\{([\s\S]+?)\}\}\}/g     // {{{ title }}}
+    }
+  });
+```
+
 ## Dependecies
 
 For this plugin to work you need:

--- a/underscore-tpl.js
+++ b/underscore-tpl.js
@@ -23,8 +23,13 @@ define(['underscore', 'text'], function (_, text) {
 
     load: function (name, req, onLoadNative, config) {
       var onLoad = function (content) {
+
         // compile the template
-        content = _.template(content);
+        if (config.templateSettings) {
+          content = _.template(content, config.templateSettings);
+        } else {
+          content = _.template(content);
+        }
 
         if (config.isBuild) {
           content = buildMap[name] = content.source;

--- a/underscore-tpl.js
+++ b/underscore-tpl.js
@@ -25,7 +25,7 @@ define(['underscore', 'text'], function (_, text) {
       var onLoad = function (content) {
 
         // compile the template
-        content = _.template(content, config.templateSettings || {});
+        content = _.template(content, config.underscoreTemplateSettings || {});
 
         if (config.isBuild) {
           content = buildMap[name] = content.source;

--- a/underscore-tpl.js
+++ b/underscore-tpl.js
@@ -25,11 +25,7 @@ define(['underscore', 'text'], function (_, text) {
       var onLoad = function (content) {
 
         // compile the template
-        if (config.templateSettings) {
-          content = _.template(content, config.templateSettings);
-        } else {
-          content = _.template(content);
-        }
+        content = _.template(content, config.templateSettings || {});
 
         if (config.isBuild) {
           content = buildMap[name] = content.source;


### PR DESCRIPTION
You can pass underscoreTemplateSettings to RequireJS config

``` javascript
requirejs.config({
  config: {
    underscoreTemplateSettings: {
      interpolate: /\{\{\s*([^#\{]+?)\s*\}\}/g,  // {{ title }}
      evaluate:    /\{\{#([\s\S]+?)\}\}/g,       // {{# console.log("stuff") }}
      escape:      /\{\{\{([\s\S]+?)\}\}\}/g     // {{{ title }}}
    }
  });
```
